### PR TITLE
Add normalization to sox call.

### DIFF
--- a/autosub/audioProcessing.py
+++ b/autosub/audioProcessing.py
@@ -34,7 +34,7 @@ def convert_samplerate(audio_path, desired_sample_rate):
         numpy buffer: audio signal stored in numpy array
     """
     
-    sox_cmd = "sox {} --type raw --bits 16 --channels 1 --rate {} --encoding signed-integer --endian little --compression 0.0 --no-dither - ".format(
+    sox_cmd = "sox {} --type raw --bits 16 --channels 1 --rate {} --encoding signed-integer --endian little --compression 0.0 --no-dither norm -0.1 - ".format(
         quote(audio_path), desired_sample_rate)
     try:
         output = subprocess.check_output(

--- a/autosub/audioProcessing.py
+++ b/autosub/audioProcessing.py
@@ -34,7 +34,7 @@ def convert_samplerate(audio_path, desired_sample_rate):
         numpy buffer: audio signal stored in numpy array
     """
     
-    sox_cmd = "sox {} --type raw --bits 16 --channels 1 --rate {} --encoding signed-integer --endian little --compression 0.0 --no-dither norm -0.1 - ".format(
+    sox_cmd = "sox {} --type raw --bits 16 --channels 1 --rate {} --encoding signed-integer --endian little --compression 0.0 --no-dither norm -3.0 - ".format(
         quote(audio_path), desired_sample_rate)
     try:
         output = subprocess.check_output(


### PR DESCRIPTION
I believe it can improve the capacity to recognize patterns, from my rudimentary tests. But I am curious about what you think.

Another, more complex option, would be to do it to each of the small chunks of audio, one by one. In that case, I have not been able to find a suitable function on pyAudioAnalysis. But I am sure there must be one way to do it.

Thank you very much for the tool.