### PR TITLE
Fix extraneous colon character in SRT/VTT files, split run-on sentences, 3 digit milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In the age of OTT platforms, there are still some who prefer to download movies/
     ```
 * WEB VTT Output (Credits - [@DerrickGibbs1](https://github.com/DerrickGibbs1)): Output VTT file including cue points for individual words. Nearly identical to VTT file downloaded from YouTube with youtube_dl.
     ```bash
-    $ python3 autosub/main.py --file ~/movie.mp4 -vtt
+    $ python3 autosub/main.py --file ~/movie.mp4 --vtt
     ```
 
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ In the age of OTT platforms, there are still some who prefer to download movies/
     ```
 * After the script finishes, the SRT file is saved in `output/`
 * Open the video file and add this SRT file as a subtitle, or you can just drag and drop in VLC.
+* The optional `--split-duration` argument allows customization of the maximum number of seconds any given subtitle is displayed for. The default is 5 seconds
+    ```bash
+    $ python3 autosub/main.py --file ~/movie.mp4 --split-duration 8
+    ```
 * WEB VTT Output (Credits - [@DerrickGibbs1](https://github.com/DerrickGibbs1)): Output VTT file including cue points for individual words. Nearly identical to VTT file downloaded from YouTube with youtube_dl.
     ```bash
     $ python3 autosub/main.py --file ~/movie.mp4 -vtt

--- a/autosub/main.py
+++ b/autosub/main.py
@@ -32,14 +32,16 @@ def sort_alphanumeric(data):
     return sorted(data, key = alphanum_key)
 
 
-def ds_process_audio(ds, audio_file, file_handle, vtt):
+def ds_process_audio(ds, audio_file, file_handle, vtt, split_duration):
     """Run DeepSpeech inference on each audio file generated after silenceRemoval
     and write to file pointed by file_handle
 
     Args:
         ds : DeepSpeech Model
         audio_file : audio file
-        file_handle : SRT file handle
+        file_handle : file handle
+        vtt: Is Video Text Tracks format
+        split_duration: for long audio segments, split the subtitle based on this number of seconds
     """
 
     global line_count
@@ -60,18 +62,40 @@ def ds_process_audio(ds, audio_file, file_handle, vtt):
 
     # Perform inference on audio segment
     metadata = ds.sttWithMetadata(audio)
-    infered_text = ''.join([x.text for x in metadata.transcripts[0].tokens])
 
     # File name contains start and end times in seconds. Extract that
     limits = audio_file.split(os.sep)[-1][:-4].split("_")[-1].split("-")
 
-    # Get time cues for each word
-    cues = [float(limits[0])] + [x.start_time + float(limits[0])
-        for x in metadata.transcripts[0].tokens if x.text == " "]
-
-    if len(infered_text) != 0:
-        line_count += 1
-        write_to_file(file_handle, infered_text, line_count, limits, vtt, cues)
+    # Run-on sentences are inferred as a single block, so write the sentence out as multiple separate lines
+    # based on a user-provided split duration.
+    current_token_index = 0
+    split_start_index = 0
+    previous_end_time = 0
+    # timestamps of word boundaries
+    cues = [float(limits[0])]
+    num_tokens = len(metadata.transcripts[0].tokens)
+    # Walk over each character in the current audio segment's inferred text
+    while current_token_index < num_tokens:
+        token = metadata.transcripts[0].tokens[current_token_index]
+        # If at a word boundary, get the timestamp for VTT cue data
+        if token.text == " ":
+            cues += [float(limits[0]) + token.start_time]
+        # time duration is exceeded and at the next word boundary
+        needs_split = ((token.start_time - previous_end_time) > split_duration) and token.text == " "
+        is_final_character = current_token_index+1 == num_tokens
+        # Write out the line
+        if needs_split or is_final_character:
+            # Determine the timestamps
+            split_limits = [float(limits[0]) + previous_end_time, float(limits[0]) + token.start_time]
+            # Convert character list to string. Upper bound has plus 1 as python list slices are [inclusive, exclusive]
+            split_inferred_text = ''.join([x.text for x in metadata.transcripts[0].tokens[split_start_index:current_token_index+1]])
+            write_to_file(file_handle, split_inferred_text, line_count, split_limits, vtt, cues)
+            # Reset and update indexes for the next subtitle split
+            previous_end_time = token.start_time
+            split_start_index = current_token_index + 1
+            cues = [float(limits[0])]
+            line_count += 1
+        current_token_index += 1
 
 
 def main():
@@ -83,6 +107,7 @@ def main():
                         help='Input video file')
     parser.add_argument('--vtt', dest="vtt", action="store_true",
                         help='Output a vtt file with cue points for individual words instead of a srt file')
+    parser.add_argument('--split-duration', type=float, help='Split run-on sentences exceededing this duration (in seconds) into multiple subtitles', default=5)
     args = parser.parse_args()
 
     for x in os.listdir():
@@ -146,7 +171,7 @@ def main():
 
         # Dont run inference on the original audio file
         if audio_segment_path.split(os.sep)[-1] != audio_file_name.split(os.sep)[-1]:
-            ds_process_audio(ds, audio_segment_path, file_handle, args.vtt)
+            ds_process_audio(ds, audio_segment_path, file_handle, args.vtt, split_duration=args.split_duration)
 
     if not args.vtt:
         print("\nSRT file saved to", srt_file_name)

--- a/autosub/writeToFile.py
+++ b/autosub/writeToFile.py
@@ -21,15 +21,15 @@ def write_to_file(file_handle, inferred_text, line_count, limits, vtt, cues):
 
     # d may be eg, '0:00:14'
     if '.' in d:
-            from_dur = "0" + str(d.split(".")[0]) + sep + str(d.split(".")[-1][:2])
+            from_dur = "0" + str(d.split(".")[0]) + sep + str(d.split(".")[-1][:3])
     else:
-        from_dur = "0" + str(d) + sep + "00"
+        from_dur = "0" + str(d) + sep + "000"
 
     d = str(datetime.timedelta(seconds=float(limits[1])))
     if '.' in d:
-        to_dur = "0" + str(d.split(".")[0]) + sep + str(d.split(".")[-1][:2])
+        to_dur = "0" + str(d.split(".")[0]) + sep + str(d.split(".")[-1][:3])
     else:
-        to_dur = "0" + str(d) + sep + "00"
+        to_dur = "0" + str(d) + sep + "000"
 
     if not vtt:
         file_handle.write(str(line_count) + "\n")

--- a/autosub/writeToFile.py
+++ b/autosub/writeToFile.py
@@ -18,15 +18,17 @@ def write_to_file(file_handle, inferred_text, line_count, limits, vtt, cues):
     sep = '.' if vtt else ','
 
     d = str(datetime.timedelta(seconds=float(limits[0])))
-    try:
-        from_dur = "0" + str(d.split(".")[0]) + sep + str(d.split(".")[-1][:2])
-    except:
+
+    # d may be eg, '0:00:14'
+    if '.' in d:
+            from_dur = "0" + str(d.split(".")[0]) + sep + str(d.split(".")[-1][:2])
+    else:
         from_dur = "0" + str(d) + sep + "00"
 
     d = str(datetime.timedelta(seconds=float(limits[1])))
-    try:
+    if '.' in d:
         to_dur = "0" + str(d.split(".")[0]) + sep + str(d.split(".")[-1][:2])
-    except:
+    else:
         to_dur = "0" + str(d) + sep + "00"
 
     if not vtt:


### PR DESCRIPTION
Fixes #21
Fixes #31 
The 3 digit millisecond commit cherry-picked of public fork. It seemed pretty reasonable to include it here.

See commit messages and referenced issues for more information.

I will cherry-pick the best changes from all the public forks in the coming days and weeks so that AutoSub can become what it should be, and I intend to help you actively maintain and develop this project over the long term.

Thanks!