### PR TITLE
fix setup packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="AutoSub",
-    packages="autosub",
+    packages=["autosub"],
     version="0.0.1",
     author="Abhiroop Talasila",
     author_email="abhiroop.talasila@gmail.com",


### PR DESCRIPTION
error was

```
running build_py
error: package directory 'a' does not exist
```

setuptools version 57.2.0