### PR TITLE
Upgrade pip in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && \
 	rm -rf /var/lib/apt/lists/*
 
 COPY $DEPSLIST ./requirements.txt
+
+# make sure pip is up-to-date
+RUN python3 -m pip install --upgrade pip
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 RUN mkdir audio output


### PR DESCRIPTION
Pip 9.0.1 seems to get installed by default, which is out of date. Upgrading pip first resolves #65 