### PR TITLE
Add support for Python 3.9

### DIFF
--- a/autosub/main.py
+++ b/autosub/main.py
@@ -5,16 +5,16 @@ import os
 import re
 import sys
 import wave
-from . import logger
+from autosub import logger
 import argparse
 
 import numpy as np
 from tqdm import tqdm
 
-from .utils import *
-from .writeToFile import write_to_file
-from .audioProcessing import extract_audio
-from .segmentAudio import remove_silent_segments
+from autosub.utils import *
+from autosub.writeToFile import write_to_file
+from autosub.audioProcessing import extract_audio
+from autosub.segmentAudio import remove_silent_segments
 
 _logger = logger.setup_applevel_logger(__name__)
 
@@ -86,7 +86,7 @@ def main():
     parser = argparse.ArgumentParser(description="AutoSub")
     parser.add_argument("--format", choices=supported_output_formats, nargs="+",
                         help="Create only certain output formats rather than all formats",
-                        default=supported_output_formats[0])
+                        default=[supported_output_formats[0]])
     parser.add_argument("--split-duration", dest="split_duration", type=float, default=5,
                         help="Split run-on sentences exceededing this duration (in seconds) into multiple subtitles")
     parser.add_argument("--dry-run", dest="dry_run", action="store_true",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pydub==0.23.1
 pyparsing==2.4.7
 python-dateutil==2.8.1
 scikit-learn
-scipy==1.4.1
+scipy==1.9.3
 six==1.15.0
 tqdm==4.44.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='<=3.6',
+    python_requires='<=3.9',
     entry_points={
         "console_scripts": ["autosub=autosub:main.main"]
     },


### PR DESCRIPTION
Adds support for Python 3.9 and fixes the issue with the default format argument where if unspecified it would create three subtitle files in ".s", ".r", and ".t" formats instead of ".srt".