### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ __pycache__
 audio/
 sub/
 output/
+AutoSub.egg-info/
+build/

--- a/autosub/audioProcessing.py
+++ b/autosub/audioProcessing.py
@@ -3,10 +3,12 @@
 
 import sys
 import shlex
-from . import logger
 import subprocess
 import numpy as np
 from os.path import basename
+
+# Local import
+import logger
 
 try:
     from shlex import quote

--- a/autosub/main.py
+++ b/autosub/main.py
@@ -5,16 +5,17 @@ import os
 import re
 import sys
 import wave
-from autosub import logger
 import argparse
 
 import numpy as np
 from tqdm import tqdm
 
-from autosub.utils import *
-from autosub.writeToFile import write_to_file
-from autosub.audioProcessing import extract_audio
-from autosub.segmentAudio import remove_silent_segments
+# Local imports
+import logger
+from utils import *
+from writeToFile import write_to_file
+from audioProcessing import extract_audio
+from segmentAudio import remove_silent_segments
 
 _logger = logger.setup_applevel_logger(__name__)
 
@@ -81,7 +82,7 @@ def ds_process_audio(ds, audio_file, output_file_handle_dict, split_duration):
 def main():
     global line_count
     supported_output_formats = ["srt", "vtt", "txt"]
-    supported_engines = ["ds", "stt"]
+    supported_engines = ["stt"]
 
     parser = argparse.ArgumentParser(description="AutoSub")
     parser.add_argument("--format", choices=supported_output_formats, nargs="+",
@@ -93,10 +94,12 @@ def main():
                         help="Perform dry-run to verify options prior to running. Also useful to instantiate \
                             cuda/tensorflow cache prior to running multiple times")
     parser.add_argument("--engine", choices=supported_engines, nargs="?", default="stt",
-                        help="Select either DeepSpeech or Coqui STT for inference. Latter is default")
+                        help="Select Coqui STT for inference. Latter is default")
     parser.add_argument("--file", required=False, help="Input video file")
-    parser.add_argument("--model", required=False, help="Input *.pbmm model file")
-    parser.add_argument("--scorer", required=False, help="Input *.scorer file")
+    parser.add_argument("--model", required=False, default="coqui-v1.0.0-english-huge-vocabulary.tflite",
+                        help="Input *.pbmm or *.tflite model file (default: coqui-v1.0.0-english-huge-vocabulary.tflite)")
+    parser.add_argument("--scorer", required=False, default="coqui-v1.0.0-english-huge-vocabulary.scorer",
+                        help="Input *.scorer file (default: coqui-v1.0.0-english-huge-vocabulary.scorer)")
     
     args = parser.parse_args()
     

--- a/autosub/segmentAudio.py
+++ b/autosub/segmentAudio.py
@@ -2,13 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import os
-from . import logger
 import numpy as np
 
-from . import trainAudio as TA
 from pydub import AudioSegment
-from . import featureExtraction as FE
 import scipy.io.wavfile as wavfile
+
+# Local imports
+import logger
+import trainAudio as TA
+import featureExtraction as FE
 
 _logger = logger.setup_applevel_logger(__name__)
 

--- a/autosub/utils.py
+++ b/autosub/utils.py
@@ -5,17 +5,14 @@ import re
 import os
 import sys
 import shutil
-from . import logger
 import subprocess
 from stt import Model as SModel
-from deepspeech import Model as DModel
+
+# Local package
+import logger
 
 _logger = logger.setup_applevel_logger(__name__)
 _models = {
-    "ds": {
-        "model": "https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-models.pbmm", 
-        "scorer": "https://github.com/mozilla/DeepSpeech/releases/download/v0.9.3/deepspeech-0.9.3-models.scorer"
-        },
     "stt": {
         "model": "https://github.com/coqui-ai/STT-models/releases/download/english/coqui/v0.9.3/model.tflite",
         "scorer": "https://github.com/coqui-ai/STT-models/releases/download/english%2Fcoqui%2Fv1.0.0-huge-vocab/huge-vocabulary.scorer"
@@ -128,10 +125,7 @@ def create_model(engine, model, scorer):
     """
 
     try:
-        if engine == "ds":
-            ds = DModel(model)
-        else:
-            ds = SModel(model)
+        ds = SModel(model)
     except:
         _logger.error("Invalid model file")
         sys.exit(1)

--- a/getmodels.sh
+++ b/getmodels.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 if [ -z $1 ]; then
-	echo "Please provide as argument the model number you wish to download. E.G. 0.9.3"
+	echo "Please provide as argument the model number you wish to download. E.G. 1.0.0"
 	exit 1;
 else
 	model=$1
 fi
 
-model_url=https://github.com/mozilla/DeepSpeech/releases/download/v$model/deepspeech-$model-models.pbmm
-scorer_url=https://github.com/mozilla/DeepSpeech/releases/download/v$model/deepspeech-$model-models.scorer
+model_url=https://github.com/coqui-ai/STT-models/releases/download/english%2Fcoqui%2Fv$model-huge-vocab/model.tflite
+scorer_url=https://github.com/coqui-ai/STT-models/releases/download/english%2Fcoqui%2Fv$model-huge-vocab/huge-vocabulary.scorer
 
-wget ${model_url} && wget ${scorer_url}
+wget ${model_url} -O "coqui-v$model-english-huge-vocabulary.tflite"
+wget ${scorer_url} -O "coqui-v$model-english-huge-vocabulary.scorer"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 cycler==0.10.0
 numpy
-stt==1.0.0
-deepspeech==0.9.3
+stt==1.4.0
 joblib==0.16.0
 kiwisolver==1.2.0
 pydub==0.23.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='<=3.9',
+    python_requires='<=3.10',
     entry_points={
         "console_scripts": ["autosub=autosub:main.main"]
     },


### PR DESCRIPTION
Adds support for Python 3.10.

One of the major problems upgrading to Python 3.10 with this is that DeepSpeech appears to be unmaintained and no longer supports 3.10.  So this also removes DeepSpeech as an engine but also updates the `getmodels.sh` script to easily download Coqui models.