### PR TITLE
fix: np.int to int

### DIFF
--- a/autosub/featureExtraction.py
+++ b/autosub/featureExtraction.py
@@ -166,11 +166,11 @@ def mfcc_filter_banks(sampling_rate, num_fft, lowfreq=133.33, linc=200 / 3,
 
         lid = np.arange(np.floor(low_freqs * num_fft / sampling_rate) + 1,
                         np.floor(cent_freqs * num_fft / sampling_rate) + 1,
-                        dtype=np.int)
+                        dtype=int)
         lslope = heights[i] / (cent_freqs - low_freqs)
         rid = np.arange(np.floor(cent_freqs * num_fft / sampling_rate) + 1,
                         np.floor(high_freqs * num_fft / sampling_rate) + 1,
-                        dtype=np.int)
+                        dtype=int)
         rslope = heights[i] / (high_freqs - cent_freqs)
         fbank[i][lid] = lslope * (nfreqs[lid] - low_freqs)
         fbank[i][rid] = rslope * (high_freqs - nfreqs[rid])


### PR DESCRIPTION
fix #80 which is an error with numpy-1.25.1

```
AttributeError: module 'numpy' has no attribute 'int'.
```

> `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
